### PR TITLE
GSSG-183 프로필 이동 버튼 추가

### DIFF
--- a/src/Auth/AuthScreen.js
+++ b/src/Auth/AuthScreen.js
@@ -61,7 +61,7 @@ export default class AuthScreen extends React.Component {
 
   onLoadInfoSuccess(resp) {
     let userInfo = UserInfo.instance;
-    userInfo.setNickName(resp.nickName);
+    userInfo.setNickName(resp.nickname);
     userInfo.setComment(resp.introduce);
     userInfo.setDog(resp.profileDog);
 

--- a/src/Cabinet/CabinetItem.js
+++ b/src/Cabinet/CabinetItem.js
@@ -45,7 +45,11 @@ export class CabinetItem extends React.Component {
         <View style={{ height: 5 }}></View>
 
         <View style={[styles.ItemProfile]}>
-          <ProfileComponent dogIndex={dogIndex} navigation={navigation}/>
+          <ProfileComponent
+            dogIndex={dogIndex}
+            navigation={navigation}
+            userName={writer.nickname}
+          />
           <View style={{ flexDirection: "row", alignItems: "center", flex: 1 }}>
             <View
               style={{

--- a/src/Cabinet/CabinetStack.js
+++ b/src/Cabinet/CabinetStack.js
@@ -5,6 +5,7 @@ import { CabinetScreen } from "./CabinetScreen";
 import { ItemDetailScreen } from "../Common/ItemDetailScreen";
 import { BackButtonImg } from "../../assets/ImageList";
 import { CommentScreen } from "../Common/CommentScreen";
+import { ProfileScreen } from "../Profile/ProfileScreen";
 
 const Stack = createStackNavigator();
 
@@ -18,6 +19,12 @@ function CabinetStack({ navigation }) {
   );
   const CommentComponent = ({ route }) => (
     <CommentScreen id={route.params.id} />
+  );
+  const ProfileScreenComponent = ({ route }) => (
+    <ProfileScreen
+      navigation={route.params.navigation}
+      userName={route.params.userName}
+    />
   );
 
   return (
@@ -55,6 +62,28 @@ function CabinetStack({ navigation }) {
             ></Image>
           ),
         }}
+      />
+      <Stack.Screen
+        name="ProfileScreen"
+        component={ProfileScreenComponent}
+        options={({ route }) => ({
+          title: route.params.userName,
+          headerTitleAlign: "center",
+          headerTitleStyle: {
+            fontFamily: "SCBold",
+            color: "#FFFFFF",
+          },
+          headerStyle: {
+            backgroundColor: "#ae9784",
+            shadowColor: "transparent",
+          },
+          headerBackImage: () => (
+            <Image
+              style={{ marginLeft: 20, width: 20, height: 20 }}
+              source={BackButtonImg}
+            ></Image>
+          ),
+        })}
       />
     </Stack.Navigator>
   );

--- a/src/Common/ItemDetailScreen.js
+++ b/src/Common/ItemDetailScreen.js
@@ -106,9 +106,15 @@ export class ItemDetailScreen extends React.Component {
             alignItems: "center",
           }}
         >
-          <ProfileComponent dogIndex={dogIndex} />
+          <ProfileComponent
+            dogIndex={dogIndex}
+            userName={writer.nickname}
+            navigation={this.props.navigation}
+          />
           <View
-            style={([commonStyles.profileView], { flexDirection: "row", flex: 1 })}
+            style={
+              ([commonStyles.profileView], { flexDirection: "row", flex: 1 })
+            }
           >
             <View
               style={{
@@ -138,9 +144,7 @@ export class ItemDetailScreen extends React.Component {
           >
             <Image
               style={{ width: 20, height: 20 }}
-              source={
-                this.state.isLike ? BoneSelectImg : BoneNoSelectImg
-              }
+              source={this.state.isLike ? BoneSelectImg : BoneNoSelectImg}
             />
           </TouchableOpacity>
           <TouchableOpacity

--- a/src/Common/ProfileComponent.js
+++ b/src/Common/ProfileComponent.js
@@ -2,21 +2,30 @@ import React from "react";
 import { TouchableOpacity, Image } from "react-native";
 import { DogImages } from "./Dogs";
 import { styles } from "../Cabinet/Styles";
-import { MyPageScreen } from "../MyPage/MyPageScreen";
 
 export class ProfileComponent extends React.Component {
+  constructor(props) {
+    super(props);
+
+    if (this.props.userName == null) {
+      alert("ProfileComponent: `userName` props does not exist.")
+      return;
+    }
+    if (this.props.navigation == null) {
+      alert("ProfileComponent: `navigation` props does not exist.");
+      return;
+    }
+    if(this.props.dogIndex == null) {
+      alert("ProfileComponent: `dogIndex` props does not exist.");
+      return;
+    }
+  }
+
   moveToProfilePage() {
-    const navigation = this.props.navigation;
-
-    // Gunny 
-    // TODO
-    // MypageScreen refectoring
-
-    // navigation.navigate("MyPageScreen", {
-    //   navigation: navigation,
-    //   //post: post,
-    // });
-    alert("프로필페이지로 이동");
+    this.props.navigation.navigate("ProfileScreen", {
+      navigation: this.props.navigation,
+      userName: this.props.userName,
+    });
   }
 
   onClicked() {

--- a/src/MyPage/MyPageStack.js
+++ b/src/MyPage/MyPageStack.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { HeaderButtons } from "react-navigation-header-buttons";
-import { MyPageScreen } from "./MyPageScreen";
+import { ProfileScreen } from "../Profile/ProfileScreen";
 import { SettingScreen } from "./SettingScreen";
 import { styles } from "./Styles";
 import { TouchableOpacity, Image } from "react-native";
@@ -9,11 +9,17 @@ import { ItemDetailScreen } from "../Common/ItemDetailScreen";
 import { BackButtonImg, AlarmImg, GearImg } from "../../assets/ImageList";
 import { ModifyAccountScreen } from "./ModifyAccountScreen";
 import { CommentScreen } from "../Common/CommentScreen";
+import UserInfo from "../Common/UserInfo";
 
 const Stack = createStackNavigator();
 
 function MyPageStack({ navigation }) {
-  const MyPageComponent = () => <MyPageScreen navigation={navigation} />;
+  const ProfileComponent = () => (
+    <ProfileScreen
+      navigation={navigation}
+      userName={UserInfo.instance.getNickName()}
+    />
+  );
   const SettingComponent = () => <SettingScreen navigation={navigation} />;
   const ModifyAccountComponent = () => (
     <ModifyAccountScreen navigation={navigation} />
@@ -25,14 +31,15 @@ function MyPageStack({ navigation }) {
     <CommentScreen id={route.params.id} />
   );
 
+  const userName = UserInfo.instance.getNickName();
   return (
     <Stack.Navigator>
       <Stack.Screen
-        name="MyPage"
-        component={MyPageComponent}
+        name="Profile"
+        component={ProfileComponent}
         options={{
-          title: "마이페이지",
-          headerShown: false,
+          title: userName,
+          headerShown: true,
           headerTitleStyle: {
             fontFamily: "SCBold",
             color: "#FFFFFF",
@@ -41,7 +48,7 @@ function MyPageStack({ navigation }) {
             backgroundColor: "#ae9784",
             shadowColor: "transparent",
           },
-          headerTitleAlign: "left",
+          headerTitleAlign: "center",
           headerRight: () => (
             <HeaderButtons>
               <TouchableOpacity

--- a/src/Profile/ProfileScreen.js
+++ b/src/Profile/ProfileScreen.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { View, ScrollView, Text, TouchableOpacity, Image } from "react-native";
-import { MyPageItem } from "./MyPageItem";
-import { styles } from "./Styles";
+import { MyPageItem } from "../MyPage/MyPageItem";
+import { styles } from "../MyPage/Styles";
 import { callApiToken } from "../Common/ApiHelper";
 import UserInfo from "../Common/UserInfo";
 import { AlarmImg, GearImg } from "../../assets/ImageList";
@@ -9,14 +9,18 @@ import { getStatusBarHeight } from "react-native-status-bar-height";
 import { DogImages } from "../Common/Dogs";
 
 let posts = null;
-export class MyPageScreen extends React.Component {
+export class ProfileScreen extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       isLoad: false,
     };
 
-    this.reqGetMyPosts();
+    if (this.props.userName == null) {
+      alert("ProfileScreen: this.props.userName is null");
+      return;
+    }
+    this.reqGetPosts(this.props.userName);
   }
 
   componentDidMount() {
@@ -24,23 +28,30 @@ export class MyPageScreen extends React.Component {
     navigation.setOptions({ tabBarVisible: true });
   }
 
-  reqGetMyPosts = async () => {
+  reqGetPosts = async (userName) => {
     const userInfo = UserInfo.instance;
-    const resp = await callApiToken(
-      "my/posts" + "?" + "page=" + 0 + "&" + "size=" + 100,
-      "GET",
-      userInfo.getJwt(),
-      null
-    );
-    if (resp == null) {
-      alert("posts GET 실패!");
-      return;
+
+    var resp = null;
+    if (userInfo.getNickName() == userName) {
+      resp = await callApiToken(
+        "my/posts" + "?" + "page=" + 0 + "&" + "size=" + 100,
+        "GET",
+        userInfo.getJwt(),
+        null
+      );
+      if (resp == null) {
+        alert("posts GET 실패!");
+        return;
+      }
+    } else {
+      // TODO
+      // Need to make a `getOtherUserPosts`
     }
 
-    this.onGetMyPostsSuccess(resp);
+    this.onGetPostsDone(resp);
   };
 
-  onGetMyPostsSuccess(resp) {
+  onGetPostsDone(resp) {
     posts = resp.posts;
     this.setState({ isLoad: true });
   }
@@ -168,7 +179,7 @@ export class MyPageScreen extends React.Component {
     const margin = getStatusBarHeight();
     return (
       <View style={{ flex: 1 }}>
-        <View
+        {/* <View
           style={{
             marginTop: margin,
             backgroundColor: "#ae9784",
@@ -207,7 +218,7 @@ export class MyPageScreen extends React.Component {
               <Image style={{ width: 20, height: 20 }} source={GearImg} />
             </TouchableOpacity>
           </View>
-        </View>
+        </View> */}
 
         {/* Fixed Line */}
         <View>


### PR DESCRIPTION
- 댓글화면, 캐비넷에서 프로필을 누르게 되면 해당 프로필로 이동하도록 했음

- MyPageScreen을 범용적인 이름인 ProfileScreen으로 이름 변경

- 프로필 화면의 상단 타이틀은 닉네임을 (가운데 정렬) 보여주도록 수정